### PR TITLE
fix: force temperature=1 when thinking is enabled or adaptive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,16 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
                   parsed.thinking = { type: "adaptive" };
                 }
 
+                // Anthropic requires temperature=1 when thinking is enabled/adaptive
+                const thinkingType = parsed.thinking?.type;
+                if (
+                  (thinkingType === "enabled" || thinkingType === "adaptive") &&
+                  parsed.temperature !== undefined &&
+                  parsed.temperature !== 1
+                ) {
+                  parsed.temperature = 1;
+                }
+
                 // Sanitize system prompt
                 if (parsed.system && Array.isArray(parsed.system)) {
                   parsed.system = parsed.system.map(


### PR DESCRIPTION
## Summary

- Fixes `temperature may only be set to 1 when thinking is enabled or in adaptive mode` API error
- The bridge auto-injects `thinking: { type: "adaptive" }` for non-Haiku models, but forwards the original `temperature` value unchanged — Anthropic rejects any value other than `1` (or omitted) when thinking is active

## Change

After the existing thinking injection block in the fetch wrapper, adds a guard that forces `temperature = 1` when:
- `thinking.type` is `"enabled"` or `"adaptive"`, AND
- `temperature` is explicitly set to something other than `1`

If `temperature` is not present in the body at all, it is left untouched (the API defaults to `1`).

## Testing

Verified on OpenCode 1.2.27 with Claude Sonnet 4.6 via OAuth — the error no longer occurs.

## Reference

https://docs.claude.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking