### PR TITLE
fix: replace authToken with apiKey to avoid @ai-sdk/anthropic v3 conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-claude-bridge",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-claude-bridge",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
   } catch {}
 
   return {
-    "experimental.chat.system.transform": (
+    "experimental.chat.system.transform": async (
       input: { model?: { providerID: string } },
       output: { system: string[] },
     ) => {
@@ -243,10 +243,12 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
 
         // OAuth active — set a placeholder so the SDK doesn't error on missing key.
         // Our fetch wrapper sets the real Authorization: Bearer header and removes x-api-key.
+        // Pass apiKey (not authToken): @ai-sdk/anthropic@3.x throws when both are present,
+        // which happens when ANTHROPIC_API_KEY is set in the desktop env before plugin init.
         process.env.ANTHROPIC_API_KEY = "oauth-placeholder";
 
         return {
-          ...(auth.access ? { authToken: auth.access } : {}),
+          apiKey: "oauth-placeholder",
 
           async fetch(input: string | URL | Request, init?: RequestInit) {
             const auth = await getAuth();


### PR DESCRIPTION
## Problem

Since opencode 1.3.4 (AI SDK v6 upgrade), the plugin throws `ProviderInitError` on **desktop** opencode. Terminal opencode with the same plugin version continues to work.

### Root cause

`@ai-sdk/anthropic` was bumped from 2.0.65 → **3.0.64** in opencode 1.3.4. Version 3.x added a validation that throws `InvalidArgumentError` when both `apiKey` and `authToken` are passed to `createAnthropic()`.

The conflict arises in this sequence:

1. Provider init runs env-scan → if `ANTHROPIC_API_KEY` is set in env (common on macOS desktop from other tools/dotfiles), `provider.key` is populated.
2. Plugin loader returns `{ authToken: auth.access, fetch }` → merged into `provider.options`.
3. `getSDK()` adds `options.apiKey = provider.key` (because `options["apiKey"] === undefined`).
4. `createAnthropic({ authToken, apiKey })` → **throws** in v3.x → wrapped as `ProviderInitError`.

**Why terminal works:** the terminal shell typically doesn't have `ANTHROPIC_API_KEY` in its env (not exported from dotfiles in non-login shells, or the plugin overwrites it fast enough), so `provider.key` is never set and there's no conflict.

## Fix

Return `apiKey: "oauth-placeholder"` from the loader instead of `authToken`. This means:

- `options["apiKey"]` is already set → `getSDK()` does **not** add the env key on top
- `createAnthropic({ apiKey: "oauth-placeholder", fetch })` — only one auth param, no throw ✅
- The custom `fetch` still removes `x-api-key` and injects `Authorization: Bearer <real_token>` as before — auth flow unchanged

Also adds missing `async` to `experimental.chat.system.transform` hook (effect fiber expects a Promise).

## Testing

Verified working on opencode 1.3.5 desktop (macOS) with `ANTHROPIC_API_KEY` present in env.