### PR TITLE
fix: OAuth authorize URL uses local callback server with real port

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,31 +40,18 @@ export const AUTHORIZE_URL =
   process.env.ANTHROPIC_AUTHORIZE_URL ||
   "https://claude.ai/oauth/authorize";
 
-// Claude Code uses a local redirect — a local HTTP server catches the callback.
-// The redirect_uri includes the dynamic port: http://localhost:{port}/callback
-// This constant is only used as a fallback; the real redirect_uri is built at
-// runtime with the actual port from startOAuthCallbackServer().
-export const REDIRECT_URI =
-  process.env.ANTHROPIC_REDIRECT_URI ||
-  "http://localhost/callback";
-
-// Manual redirect URL — used when local server can't receive the callback
+// Manual redirect URL — used when the local server can't receive the callback
 // (e.g., user copies the code from the browser). This matches Claude CLI's
 // MANUAL_REDIRECT_URL from the production OAuth config.
 export const MANUAL_REDIRECT_URL =
   process.env.ANTHROPIC_MANUAL_REDIRECT_URL ||
   "https://platform.claude.com/oauth/code/callback";
 
-// Default port for the local OAuth callback server (0 = auto-assign)
-export const OAUTH_CALLBACK_PORT = parseInt(
-  process.env.ANTHROPIC_OAUTH_CALLBACK_PORT || "0",
-  10,
-);
-
-// Exact scopes from Claude Code 2.1.98 binary
+// All OAuth scopes — union of Console + Claude.ai scopes, matching Claude CLI's
+// ALL_OAUTH_SCOPES. Includes org:create_api_key for Console -> Claude.ai redirect.
 export const SCOPES =
   process.env.ANTHROPIC_SCOPES ||
-  "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+  "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 
 export const CLI_VERSION =
   process.env.ANTHROPIC_CLI_VERSION || detectClaudeVersion();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   exchangeCodeForTokens,
   parseAuthCode,
   refreshTokens,
+  startOAuthCallbackServer,
 } from "./oauth.js";
 import { getClaudeTokens, readClaudeCredentials } from "./keychain.js";
 import {
@@ -211,6 +212,35 @@ async function refreshAuth(
     return fresh.access;
   }
   return null;
+}
+
+/** Best-effort browser open — tries multiple methods on each platform. */
+function openBrowser(url: string): void {
+  (async () => {
+    const { execFileSync } = await import("node:child_process");
+
+    if (process.platform === "darwin") {
+      const uid = String(process.getuid?.() ?? "");
+      const attempts: Array<() => void> = [
+        () => execFileSync("/bin/launchctl", ["asuser", uid, "/usr/bin/open", url], { timeout: 5000 }),
+        () => execFileSync("/usr/bin/open", [url], { timeout: 3000 }),
+        () => execFileSync("/usr/bin/osascript", ["-e", `open location "${url}"`], { timeout: 3000 }),
+      ];
+      for (const attempt of attempts) {
+        try { attempt(); break; } catch {}
+      }
+    } else if (process.platform === "win32") {
+      try { execFileSync("cmd", ["/c", "start", url], { timeout: 3000 }); } catch {}
+    } else {
+      const attempts: Array<() => void> = [
+        () => execFileSync("/usr/bin/xdg-open", [url], { timeout: 3000 }),
+        () => execFileSync("/usr/bin/open", [url], { timeout: 3000 }),
+      ];
+      for (const attempt of attempts) {
+        try { attempt(); break; } catch {}
+      }
+    }
+  })().catch(() => {});
 }
 
 /** Merge HeadersInit (Headers | string[][] | Record) onto a Headers object. */
@@ -776,69 +806,104 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
           label: "Claude Pro / Max (OAuth)",
           type: "oauth" as const,
           authorize: async () => {
+            // First try: auto-bootstrap from Claude CLI keychain
             const tokens = getClaudeTokens();
             if (tokens) {
               await storeAuth(client, tokens);
               return {
-                instructions: "✓ Connected via Claude CLI — press Esc, then restart OpenCode if Anthropic models aren't visible",
+                instructions: "Connected via Claude CLI — press Esc, then restart OpenCode if Anthropic models aren't visible",
                 method: "code" as const,
                 callback: async () => ({ type: "success" as const, ...tokens }),
               };
             }
 
+            // Start a local HTTP server to capture the OAuth redirect.
+            // This gives us an ephemeral port so the redirect_uri is
+            // http://localhost:{port}/callback — matching Claude Code's flow.
+            let callbackServer: Awaited<ReturnType<typeof startOAuthCallbackServer>> | null = null;
+            try {
+              callbackServer = await startOAuthCallbackServer();
+            } catch (err) {
+              console.error(`[opencode-oauth] Failed to start callback server: ${err}`);
+            }
+
+            if (callbackServer) {
+              const { url, manualUrl, verifier, port } = callbackServer;
+              const redirectUri = `http://localhost:${port}/callback`;
+
+              // Best-effort browser open
+              openBrowser(url);
+
+              // Race: localhost callback vs manual code paste.
+              // If the browser redirects to localhost, the callback server
+              // captures the code automatically. Otherwise, the user can
+              // paste the code from the manual-flow URL.
+              //
+              // We set up the automatic flow listener in the background.
+              // If the user pastes a code first, that wins.
+              let autoCode: string | null = null;
+              callbackServer.waitForCode().then((code) => {
+                autoCode = code;
+              }).catch(() => {});
+
+              return {
+                url,
+                instructions: `Opening browser for OAuth...\n\nIf the browser redirected back successfully, just press Enter.\nOtherwise, open this URL and paste the code:\n${manualUrl}`,
+                method: "code" as const,
+                callback: async (manualInput: string) => {
+                  try {
+                    // Brief pause to let the auto-flow resolve if it just arrived
+                    if (!autoCode && !manualInput?.trim()) {
+                      await new Promise((r) => setTimeout(r, 500));
+                    }
+
+                    if (autoCode) {
+                      // Auto-flow captured the code via localhost redirect
+                      const tokens = exchangeCodeForTokens(autoCode, verifier, redirectUri);
+                      await storeAuth(client, tokens);
+                      callbackServer?.close();
+                      return { type: "success" as const, ...tokens };
+                    }
+
+                    const code = parseAuthCode(manualInput);
+                    if (!code) {
+                      console.error("[opencode-oauth] No authorization code received");
+                      callbackServer?.close();
+                      return { type: "failed" as const };
+                    }
+
+                    // Manual flow — redirect_uri defaults to MANUAL_REDIRECT_URL
+                    const tokens = exchangeCodeForTokens(code, verifier);
+                    await storeAuth(client, tokens);
+                    callbackServer?.close();
+                    return { type: "success" as const, ...tokens };
+                  } catch (err) {
+                    console.error(`[opencode-oauth] Token exchange failed: ${err}`);
+                    callbackServer?.close();
+                    return { type: "failed" as const };
+                  }
+                },
+              };
+            }
+
+            // Fallback: no callback server — use manual redirect URL flow only.
+            // This is the path for environments where we can't bind localhost.
             const { url, verifier } = createAuthorizationRequest();
 
-            // Best-effort browser open — try launchctl asuser (escapes sidecar sandbox),
-            // plain open, and osascript in order. Also write a .command file to Desktop.
-            (async () => {
-              const { execFileSync } = await import("node:child_process");
-              const { writeFileSync, chmodSync } = await import("node:fs");
-              const { homedir } = await import("node:os");
-              const { join } = await import("node:path");
-
-              if (process.platform === "darwin") {
-                // Write .command file to Desktop as a guaranteed fallback
-                try {
-                  const safe = url.replace(/'/g, "'\\''");
-                  const script = `#!/bin/bash\n/usr/bin/open '${safe}'\nrm -f "$0"\n`;
-                  const scriptPath = join(homedir(), "Desktop", "opencode-oauth.command");
-                  writeFileSync(scriptPath, script);
-                  chmodSync(scriptPath, 0o755);
-                } catch {}
-
-                // Try to open browser directly
-                const uid = String(process.getuid?.() ?? "");
-                const attempts: Array<() => void> = [
-                  () => execFileSync("/bin/launchctl", ["asuser", uid, "/usr/bin/open", url], { timeout: 5000 }),
-                  () => execFileSync("/usr/bin/open", [url], { timeout: 3000 }),
-                  () => execFileSync("/usr/bin/osascript", ["-e", `open location "${url}"`], { timeout: 3000 }),
-                ];
-                for (const attempt of attempts) {
-                  try { attempt(); break; } catch {}
-                }
-              } else if (process.platform === "win32") {
-                try { execFileSync("cmd", ["/c", "start", url], { timeout: 3000 }); } catch {}
-              } else {
-                const attempts: Array<() => void> = [
-                  () => execFileSync("/usr/bin/xdg-open", [url], { timeout: 3000 }),
-                  () => execFileSync("/usr/bin/open", [url], { timeout: 3000 }),
-                ];
-                for (const attempt of attempts) {
-                  try { attempt(); break; } catch {}
-                }
-              }
-            })().catch(() => {});
+            openBrowser(url);
 
             return {
               url,
-              instructions: `Opening browser… If nothing opens, double-click 'opencode-oauth.command' on your Desktop, then paste the authorization code below:\n\n${url}`,
+              instructions: `Opening browser for OAuth...\n\nAfter authorizing, you'll see a code — paste it below:\n${url}`,
               method: "code" as const,
               callback: async (code: string) => {
                 try {
+                  // redirect_uri defaults to MANUAL_REDIRECT_URL in exchangeCodeForTokens
                   const tokens = exchangeCodeForTokens(parseAuthCode(code), verifier);
                   await storeAuth(client, tokens);
                   return { type: "success" as const, ...tokens };
-                } catch {
+                } catch (err) {
+                  console.error(`[opencode-oauth] Token exchange failed: ${err}`);
                   return { type: "failed" as const };
                 }
               },

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -154,6 +154,9 @@ export function startOAuthCallbackServer(): Promise<OAuthCallbackServer> {
       codeReject = rej;
     });
 
+    const escapeHtml = (s: string) =>
+      s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url || "/", `http://localhost`);
 
@@ -164,7 +167,7 @@ export function startOAuthCallbackServer(): Promise<OAuthCallbackServer> {
         if (error) {
           const desc = url.searchParams.get("error_description") || error;
           res.writeHead(200, { "Content-Type": "text/html" });
-          res.end(`<html><body><h2>Authorization failed</h2><p>${desc}</p><p>You can close this window.</p></body></html>`);
+          res.end(`<html><body><h2>Authorization failed</h2><p>${escapeHtml(desc)}</p><p>You can close this window.</p></body></html>`);
           codeReject?.(new Error(`OAuth error: ${desc}`));
           return;
         }

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,10 +1,11 @@
 import { randomBytes, createHash } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { execSync } from "node:child_process";
 import {
   CLIENT_ID,
   TOKEN_URL,
   AUTHORIZE_URL,
-  REDIRECT_URI,
+  MANUAL_REDIRECT_URL,
   SCOPES,
   USER_AGENT,
 } from "./constants.js";
@@ -13,6 +14,23 @@ export interface OAuthTokens {
   access: string;
   refresh: string;
   expires: number;
+}
+
+export interface OAuthCallbackServer {
+  /** The URL the user should open to authorize. */
+  url: string;
+  /** A manual-flow URL the user can paste a code from if localhost redirect doesn't work. */
+  manualUrl: string;
+  /** The PKCE code verifier (needed for token exchange). */
+  verifier: string;
+  /** The state parameter (used for CSRF validation). */
+  state: string;
+  /** The port the local server is listening on. */
+  port: number;
+  /** Wait for the authorization code to arrive via localhost redirect. Resolves with the code. */
+  waitForCode: () => Promise<string>;
+  /** Stop the callback server. */
+  close: () => void;
 }
 
 function base64url(buf: Buffer): string {
@@ -84,24 +102,149 @@ function parseTokenResponse(status: number, body: string, label: string): OAuthT
   };
 }
 
-export function createAuthorizationRequest(
-  redirectUri?: string,
-): { url: string; verifier: string } {
+/**
+ * Build PKCE challenge and state, then construct both automatic (localhost
+ * redirect) and manual (platform.claude.com redirect) authorization URLs.
+ */
+function buildAuthUrls(
+  port: number,
+): { automaticUrl: string; manualUrl: string; verifier: string; state: string } {
   const verifier = base64url(randomBytes(64));
   const challenge = base64url(createHash("sha256").update(verifier).digest());
-  const state = base64url(randomBytes(16));
+  const state = base64url(randomBytes(32));
+
+  const automaticRedirectUri = `http://localhost:${port}/callback`;
+
+  const buildUrl = (redirectUri: string): string => {
+    const params = new URLSearchParams({
+      code: "true",
+      client_id: CLIENT_ID,
+      response_type: "code",
+      redirect_uri: redirectUri,
+      scope: SCOPES,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      state,
+    });
+    return `${AUTHORIZE_URL}?${params}`;
+  };
+
+  return {
+    automaticUrl: buildUrl(automaticRedirectUri),
+    manualUrl: buildUrl(MANUAL_REDIRECT_URL),
+    verifier,
+    state,
+  };
+}
+
+/**
+ * Start a local HTTP server to receive the OAuth callback redirect.
+ * Returns a server handle with the authorization URLs, a promise that
+ * resolves when the auth code arrives, and a close() method.
+ *
+ * This matches Claude Code's approach: an ephemeral port on localhost
+ * captures the redirect. The redirect_uri includes the real port.
+ */
+export function startOAuthCallbackServer(): Promise<OAuthCallbackServer> {
+  return new Promise((resolve, reject) => {
+    let codeResolve: ((code: string) => void) | null = null;
+    let codeReject: ((err: Error) => void) | null = null;
+    const codePromise = new Promise<string>((res, rej) => {
+      codeResolve = res;
+      codeReject = rej;
+    });
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url || "/", `http://localhost`);
+
+      if (url.pathname === "/callback") {
+        const code = url.searchParams.get("code");
+        const error = url.searchParams.get("error");
+
+        if (error) {
+          const desc = url.searchParams.get("error_description") || error;
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(`<html><body><h2>Authorization failed</h2><p>${desc}</p><p>You can close this window.</p></body></html>`);
+          codeReject?.(new Error(`OAuth error: ${desc}`));
+          return;
+        }
+
+        if (code) {
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(`<html><body><h2>Authorization successful</h2><p>You can close this window and return to OpenCode.</p></body></html>`);
+          codeResolve?.(code);
+          return;
+        }
+
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("Missing authorization code");
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+    });
+
+    // Timeout: close the server after 5 minutes if no code arrives
+    const timeout = setTimeout(() => {
+      codeReject?.(new Error("OAuth callback timed out after 5 minutes"));
+      server.close();
+    }, 5 * 60 * 1000);
+
+    // Listen on port 0 = OS assigns an ephemeral port
+    server.listen(0, "localhost", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Failed to get server address"));
+        return;
+      }
+
+      const port = addr.port;
+      const { automaticUrl, manualUrl, verifier, state } = buildAuthUrls(port);
+
+      resolve({
+        url: automaticUrl,
+        manualUrl,
+        verifier,
+        state,
+        port,
+        waitForCode: () => codePromise,
+        close: () => {
+          clearTimeout(timeout);
+          server.close();
+        },
+      });
+    });
+
+    server.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Legacy createAuthorizationRequest for backward compatibility.
+ * Uses MANUAL_REDIRECT_URL since there's no local server.
+ */
+export function createAuthorizationRequest(
+  redirectUri?: string,
+): { url: string; verifier: string; state: string } {
+  const verifier = base64url(randomBytes(64));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  const state = base64url(randomBytes(32));
 
   const params = new URLSearchParams({
+    code: "true",
     response_type: "code",
     client_id: CLIENT_ID,
-    redirect_uri: redirectUri || REDIRECT_URI,
+    redirect_uri: redirectUri || MANUAL_REDIRECT_URL,
     scope: SCOPES,
     code_challenge: challenge,
     code_challenge_method: "S256",
     state,
   });
 
-  return { url: `${AUTHORIZE_URL}?${params}`, verifier };
+  return { url: `${AUTHORIZE_URL}?${params}`, verifier, state };
 }
 
 export function parseAuthCode(raw: string): string {
@@ -134,7 +277,7 @@ export function exchangeCodeForTokens(
     code,
     code_verifier: verifier,
     client_id: CLIENT_ID,
-    redirect_uri: redirectUri || REDIRECT_URI,
+    redirect_uri: redirectUri || MANUAL_REDIRECT_URL,
   });
   return parseTokenResponse(status, body, "Token exchange");
 }


### PR DESCRIPTION
## Summary

Fixes #2 — "Invalid request format" when the OAuth fallback flow is triggered.

- **Root cause**: The authorize URL used `redirect_uri=http://localhost/callback` (no port, no server listening). Anthropic's OAuth endpoint rejects this per RFC 8252 loopback redirect requirements.
- **Fix**: Start a local HTTP callback server on an OS-assigned ephemeral port, so the `redirect_uri` becomes `http://localhost:{port}/callback` — matching how Claude Code does it.

## Changes

- **`src/oauth.ts`** — Add `startOAuthCallbackServer()` that binds to port 0, captures the redirect code at `/callback`, and times out after 5 minutes. Builds both an automatic URL (localhost redirect) and a manual URL (`platform.claude.com/oauth/code/callback` fallback).
- **`src/constants.ts`** — Add `org:create_api_key` to scopes (matches Claude Code's `ALL_OAUTH_SCOPES`). Remove unused `REDIRECT_URI` and `OAUTH_CALLBACK_PORT` constants.
- **`src/index.ts`** — Rewrite the OAuth authorize method to use the callback server. Extract `openBrowser()` helper. Support both auto-redirect (localhost captures code) and manual paste (user copies code from Anthropic's hosted callback page). Handle empty input gracefully when auto-redirect already succeeded.

## What was happening

1. Claude CLI keychain tokens expire or get rotated
2. Bridge correctly falls through to browser OAuth flow
3. Authorize URL is shown with `redirect_uri=http://localhost/callback` (no port)
4. Anthropic rejects the request → user sees "Invalid request format"

## What happens now

1. Keychain tokens expire → bridge falls through to OAuth (same as before)
2. Bridge starts a local HTTP server on an ephemeral port (e.g., 59360)
3. Authorize URL uses `redirect_uri=http://localhost:59360/callback`
4. Browser opens, user authorizes, browser redirects back to localhost
5. Callback server captures the code, token exchange succeeds
6. If localhost redirect doesn't work, user can use the manual URL and paste the code