### PR TITLE
Fix Windows shell compatibility in version detection and OAuth helpers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -6,9 +6,10 @@ import { join } from "node:path";
 function detectClaudeVersion(): string {
   // Try to read version from installed Claude CLI
   try {
-    const version = execSync("claude --version 2>/dev/null", {
+    const version = execFileSync("claude", ["--version"], {
       encoding: "utf8",
       timeout: 3000,
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
     const match = version.match(/^(\d+\.\d+\.\d+)/);
     if (match) return match[1];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
+import { buildTokenCurlArgs } from "./oauth.js";
 
 // ── Helpers (extracted / reimplemented from index.ts for unit testing) ────────
 
@@ -117,5 +118,18 @@ describe("temperature coercion", () => {
       JSON.stringify({ model: "claude-sonnet-4-6", messages: [] }),
     );
     assert.equal(out.temperature, undefined);
+  });
+});
+
+describe("windows compatibility regressions", () => {
+  it("builds curl args without shell escaping requirements", () => {
+    const payload = JSON.stringify({ note: "O'Reilly" });
+    const args = buildTokenCurlArgs(payload);
+
+    assert.equal(args[0], "-s");
+    assert.equal(args[1], "-w");
+    assert.equal(args[2], "\n__HTTP_STATUS__%{http_code}");
+    assert.equal(args[args.length - 2], "-d");
+    assert.equal(args[args.length - 1], payload);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ function openBrowser(url: string): void {
         try { attempt(); break; } catch {}
       }
     } else if (process.platform === "win32") {
-      try { execFileSync("cmd", ["/c", "start", url], { timeout: 3000 }); } catch {}
+      try { execFileSync("cmd", ["/c", "start", "", url], { timeout: 3000 }); } catch {}
     } else {
       const attempts: Array<() => void> = [
         () => execFileSync("/usr/bin/xdg-open", [url], { timeout: 3000 }),

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,6 +1,6 @@
 import { randomBytes, createHash } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   CLIENT_ID,
   TOKEN_URL,
@@ -38,7 +38,7 @@ function base64url(buf: Buffer): string {
 }
 
 function sleep(ms: number): void {
-  execSync(`sleep ${(ms / 1000).toFixed(3)}`, { timeout: 60000 });
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 /**
@@ -50,17 +50,30 @@ function curlPost(
   retries = 3,
 ): { status: number; body: string } {
   const payload = JSON.stringify(body);
-  const escaped = payload.replace(/'/g, "'\\''");
 
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
-      const result = execSync(
-        `curl -s -w '\\n__HTTP_STATUS__%{http_code}' ` +
-          `-X POST '${TOKEN_URL}' ` +
-          `-H 'Content-Type: application/json' ` +
-          `-H 'User-Agent: ${USER_AGENT}' ` +
-          `-d '${escaped}'`,
-        { timeout: 30000, encoding: "utf8" },
+      const result = execFileSync(
+        "curl",
+        [
+          "-s",
+          "-w",
+          "\n__HTTP_STATUS__%{http_code}",
+          "-X",
+          "POST",
+          TOKEN_URL,
+          "-H",
+          "Content-Type: application/json",
+          "-H",
+          `User-Agent: ${USER_AGENT}`,
+          "-d",
+          payload,
+        ],
+        {
+          timeout: 30000,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        },
       );
 
       const parts = result.split("\n__HTTP_STATUS__");

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -41,6 +41,23 @@ function sleep(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+export function buildTokenCurlArgs(payload: string): string[] {
+  return [
+    "-s",
+    "-w",
+    "\n__HTTP_STATUS__%{http_code}",
+    "-X",
+    "POST",
+    TOKEN_URL,
+    "-H",
+    "Content-Type: application/json",
+    "-H",
+    `User-Agent: ${USER_AGENT}`,
+    "-d",
+    payload,
+  ];
+}
+
 /**
  * curl-based token exchange to avoid Bun/runtime fetch injecting
  * forbidden headers (Origin, Referer, Sec-Fetch-*) that trigger 429s.
@@ -55,20 +72,7 @@ function curlPost(
     try {
       const result = execFileSync(
         "curl",
-        [
-          "-s",
-          "-w",
-          "\n__HTTP_STATUS__%{http_code}",
-          "-X",
-          "POST",
-          TOKEN_URL,
-          "-H",
-          "Content-Type: application/json",
-          "-H",
-          `User-Agent: ${USER_AGENT}`,
-          "-d",
-          payload,
-        ],
+        buildTokenCurlArgs(payload),
         {
           timeout: 30000,
           encoding: "utf8",


### PR DESCRIPTION
## Summary
- replace shell-dependent `claude --version 2>/dev/null` with `execFileSync` so version detection works under Windows
- replace shell `sleep` and shell-quoted `curl` in OAuth token exchange with cross-platform process and JS logic
- use `cmd /c start \"\" <url>` on Windows so browser launch handles URLs more reliably

## Testing
- npm run build

Fixes #4