### PR TITLE
merge opencode's original system prompt (including AGENTS.md) into system prompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -213,7 +213,7 @@ export function shouldInjectClaudeTools(input: {
   model?: string;
   requestUrl?: string;
   tools?: unknown;
-})g boolean {
+}): boolean {
   if (!shouldUseClaudeToolSchemas({ model: input.model, requestUrl: input.requestUrl })) {
     return false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,7 +213,7 @@ export function shouldInjectClaudeTools(input: {
   model?: string;
   requestUrl?: string;
   tools?: unknown;
-}): boolean {
+})g boolean {
   if (!shouldUseClaudeToolSchemas({ model: input.model, requestUrl: input.requestUrl })) {
     return false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -738,7 +738,7 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
                   billingHeader = parsed.system[0]?.text || billingHeader;
                 }
 
-                // If we have a locally captured Claude Code system prompt, prefer it.
+// Merge Claude Code system prompt with opencode's existing system (including AGENTS.md).
                 if (cachedClaudeSystem) {
                   const rewritten = rewriteSystemBlocksForModel(
                     cachedClaudeSystem,
@@ -746,6 +746,7 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
                   );
                   parsed.system = [
                     { type: "text", text: billingHeader },
+                    ...parsed.system,
                     ...rewritten,
                   ];
                 } else if (parsed.system && Array.isArray(parsed.system)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -738,7 +738,7 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
                   billingHeader = parsed.system[0]?.text || billingHeader;
                 }
 
-// Merge Claude Code system prompt with opencode's existing system (including AGENTS.md).
+                // Merge Claude Code system prompt with opencode's existing system (including AGENTS.md).
                 if (cachedClaudeSystem) {
                   const rewritten = rewriteSystemBlocksForModel(
                     cachedClaudeSystem,


### PR DESCRIPTION
I was surprised that my global AGENTS.md file was being ignored, and inspecting that led me here. 

Previously the bridge code would replace opencode's entire system prompt (including AGENTS.md content) with the Claude Code identity blocks. This PR implements merging billingHeader, opencodeSystem and claudeCodeIdentity.