### PR TITLE
fix: strip cache_control from Anthropic system blocks

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,12 +18,15 @@ import {
   shouldUseClaudeToolSchemas,
 } from "./claude-tools.js";
 import { extractOAuthErrorDetail } from "./oauth.js";
-import { getClaudeToolsForActiveOpenCodeTools, shouldInjectClaudeTools, stripAssistantPrefillForClaude } from "./index.js";
-import { createSseProcessor, parseSseEvent, buildSseEvent } from "./stream.js";
 import {
   deriveModelDisplayName,
+  getClaudeToolsForActiveOpenCodeTools,
   rewriteSystemBlocksForModel,
+  shouldInjectClaudeTools,
+  stripAssistantPrefillForClaude,
+  stripSystemCacheControl,
 } from "./index.js";
+import { createSseProcessor, parseSseEvent, buildSseEvent } from "./stream.js";
 
 // ── Helpers (extracted / reimplemented from index.ts for unit testing) ────────
 
@@ -170,6 +173,18 @@ describe("Claude assistant prefill stripping", () => {
       { role: "assistant", content: "Real assistant content" },
     ];
     assert.deepEqual(stripAssistantPrefillForClaude(input), input);
+  });
+});
+
+describe("system cache control", () => {
+  it("strips cache_control from system blocks", () => {
+    assert.deepEqual(stripSystemCacheControl([
+      { type: "text", text: "a", cache_control: { type: "ephemeral" } },
+      { type: "text", text: "b" },
+    ]), [
+      { type: "text", text: "a" },
+      { type: "text", text: "b" },
+    ]);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,16 @@ export function rewriteSystemBlocksForModel(
   });
 }
 
+export function stripSystemCacheControl(
+  system: Array<{ type?: string; text?: string; cache_control?: unknown }>,
+): Array<{ type?: string; text?: string }> {
+  return system.map((block) => {
+    if (!("cache_control" in block)) return block;
+    const { cache_control, ...rest } = block;
+    return rest;
+  });
+}
+
 export function shouldInjectClaudeTools(input: {
   model?: string;
   requestUrl?: string;
@@ -762,6 +772,7 @@ const OpenCodeClaudeBridge = async ({ client }: { client: PluginClient }) => {
                   // Otherwise keep the existing prompt but shape it closer to Claude Code.
                   parsed.system = normalizeSystemBlocks(parsed.system);
                 }
+                parsed.system = stripSystemCacheControl(parsed.system);
 
                 // Keep OpenCode's default tool schemas for non-Claude targets.
                 // Claude wire schemas are only useful for Anthropic-native


### PR DESCRIPTION
Anthropic's API rejects requests with more than 4 cache_control blocks. OpenCode adds its own prompt-caching markers, which can push the total past the limit when the cached Claude Code system prompt also carries cache_control markers. Strip them unconditionally from system blocks before sending — opencode handles its own caching independently.

Adds stripSystemCacheControl() helper with a unit test.